### PR TITLE
docs: add PATH note for go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ your git/go setup is trying to fetch directly from GitHub without credentials. U
 
 Note: the canonical module path is `github.com/thellimist/clihub` (not `github.com/clihub/clihub`).
 
+`go install` places the binary in `$GOBIN` (or `$GOPATH/bin`, typically `~/go/bin`). If the `clihub` command is not found after install, make sure that directory is in your `PATH`:
+
+```bash
+export PATH="$HOME/go/bin:$PATH"
+```
+
 Or build from source:
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a note under the `go install` section explaining that `~/go/bin` must be on `PATH`
- The build-from-source section already has equivalent guidance for `~/.local/bin`, but `go install` users hit the same "command not found" issue with a different directory

## Context

Ran `go install github.com/thellimist/clihub@latest` successfully, but `clihub` wasn't found because `~/go/bin` wasn't on `PATH`. The README covers this for build-from-source (`~/.local/bin`) but not for `go install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)